### PR TITLE
Add Ledvance support

### DIFF
--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -361,6 +361,7 @@
                         <select id="appType" class="value">
                             <option value="smart_life">SmartLife</option>
                             <option value="tuya_smart">Tuya Smart</option>
+                            <option value="ledvance">Ledvance</option>
                         </select>
                         <label for="region" class="translate">Mobile app Account Type</label>
                     </div>

--- a/lib/appcloud.js
+++ b/lib/appcloud.js
@@ -29,6 +29,14 @@ class AppCloud {
                 secret2: 'vay9g59g9g99qf3rtqptmc3emhkanwkx',
                 secret: 'aq7xvqcyqcnegvew793pqjmhv77rneqc',
             };
+        } else if (appType === 'ledvance') {
+            this.apiKeys = {
+                ttid: 'sdk_tuya@fx3fvkvusmw45d7jn8xh',
+                key: 'fx3fvkvusmw45d7jn8xh',
+                secret: 'cgqx3ku34mh5qdesd7fcaru3gx7tyurr',
+                secret2: 'armptsqyfpxa4ftvtc739ardncett3uy',
+                certSign: 'A',
+            }
         } else {
             this.apiKeys = {
                 ttid: 'smart_life',

--- a/main.js
+++ b/main.js
@@ -2254,7 +2254,8 @@ async function connectMqtt() {
         adapter.config.cloudUsername,
         adapter.config.cloudPassword,
         adapter.config.appPhoneCode || 49,
-        adapter.config.appType === 'tuya_smart' ? 'tuyaSmart' : 'smartLife',
+        adapter.config.appType === 'tuya_smart' ? 'tuyaSmart' :
+	 (adapter.config.appType === 'ledvance' ? 'ledvance' : 'smartLife'),
         {log: adapter.log.debug.bind(this)},
     );
 


### PR DESCRIPTION
While trying to get my shiny new Ledvance smart plugs to work, I found that none of the embedded keys to access Tuya work. However, there was a python tool that was able to access the APIs just fine:

  https://github.com/FlagX/ha-ledvance-tuya-resync-localkey.git

This patch adds the Ledvance keys from that tool into the iobroker code. With this, I can successfully access power measurements from my Ledvance power switches.